### PR TITLE
Investigate plus sign before tasks.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ Thumbs.db
 *.swo
 
 # === Database files ===
-todo.db
+tasks.db
 
 # === Environment files (optional) ===
 # Uncomment if using dotenv or storing secrets locally


### PR DESCRIPTION
Rename `todo.db` to `tasks.db` in `.gitignore` to correctly ignore the project's database file.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0e957ec-2e97-4a25-b9a9-4502a1c28020">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0e957ec-2e97-4a25-b9a9-4502a1c28020">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

